### PR TITLE
Introduces an always wrap architecture

### DIFF
--- a/spec/QueueMiddlewareSpec.php
+++ b/spec/QueueMiddlewareSpec.php
@@ -28,13 +28,16 @@ class QueueMiddlewareSpec extends ObjectBehavior
 
     function it_executes_a_command(Queue $queue, QueueableCommand $command)
     {
+        $command->shouldBeQueued()->willReturn(true);
+
         $queue->enqueue(Argument::type('Bernard\Envelope'))->shouldBeCalled();
 
         $this->execute($command, function() {});
     }
 
-    function it_executes_invokes_the_next_middleware(Queue $queue, Command $command, Middleware $middleware)
+    function it_executes_invokes_the_next_middleware(Queue $queue, QueueableCommand $command, Middleware $middleware)
     {
+        $command->shouldBeQueued()->willReturn(false);
         $queue->enqueue(Argument::type('Bernard\Envelope'))->shouldNotBeCalled();
         $next = function() {};
         $middleware->execute($command, $next)->willReturn(true);

--- a/spec/RouterSpec.php
+++ b/spec/RouterSpec.php
@@ -28,6 +28,7 @@ class RouterSpec extends ObjectBehavior
     function it_maps_an_envelope(Envelope $envelope, QueueableCommand $command, CommandBus $commandBus)
     {
         $envelope->getMessage()->willReturn($command);
+        $command->setQueueDecision(false)->shouldBeCalled();
 
         $this->map($envelope)->shouldReturn([$commandBus, 'handle']);
     }

--- a/src/CommandWrapper.php
+++ b/src/CommandWrapper.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace League\Tactician\Bernard;
+
+use League\Tactician\Command;
+
+/**
+ * Creates a command wrapper for
+ */
+class CommandWrapper implements QueueableCommand
+{
+    use QueueDecision;
+
+    /**
+     * @var Command
+     */
+    protected $command;
+
+    /**
+     * @param Command $command
+     */
+    public function __construct(Command $command)
+    {
+        $this->command = $command;
+    }
+
+    /**
+     * Returns the command
+     *
+     * @return Command
+     */
+    public function getCommand()
+    {
+        return $command;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'wrapped_command';
+    }
+}

--- a/src/QueueDecision.php
+++ b/src/QueueDecision.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace League\Tactician\Bernard;
+
+/**
+ * Helps deciding whether the command should be queued or not
+ */
+trait QueueDecision
+{
+    /**
+     * @var boolean
+     */
+    protected $shouldBeQueued = true;
+
+    /**
+     * Checks whether the command should be queued or not
+     *
+     * @return boolean
+     */
+    public function shouldBeQueued()
+    {
+        return $this->shouldBeQueued;
+    }
+
+    /**
+     * Sets the queue decision
+     *
+     * @param boolean $decision
+     */
+    public function setQueueDecision($decision = true)
+    {
+        $this->shouldBeQueued = (bool) $decision;
+    }
+}

--- a/src/QueueMiddleware.php
+++ b/src/QueueMiddleware.php
@@ -31,10 +31,17 @@ class QueueMiddleware implements Middleware
      */
     public function execute(Command $command, callable $next)
     {
-        if ($command instanceof Message) {
-            $this->queue->enqueue(new Envelope($command));
+        if (!$command instanceof QueueableCommand) {
+            $command = new CommandWrapper($command);
+        }
 
+        if ($command->shouldBeQueued()) {
+            $this->queue->enqueue(new Envelope($command));
             return;
+        }
+
+        if ($command instanceof CommandWrapper) {
+            $command = $command->getCommand();
         }
 
         return $next($command);

--- a/src/QueueableCommand.php
+++ b/src/QueueableCommand.php
@@ -10,5 +10,17 @@ use League\Tactician\Command;
  */
 interface QueueableCommand extends Command, Message
 {
+    /**
+     * Checks whether the command should be queued or not
+     *
+     * @return boolean
+     */
+    public function shouldBeQueued();
 
+    /**
+     * Sets the queueability decision
+     *
+     * @param boolean $decision
+     */
+    public function setQueueDecision($decision = true);
 }

--- a/src/Router.php
+++ b/src/Router.php
@@ -33,6 +33,8 @@ class Router implements \Bernard\Router
             throw new ReceiverNotFoundException();
         }
 
+        $envelope->getMessage()->setQueueDecision(false);
+
         return [$this->commandBus, 'handle'];
     }
 }


### PR DESCRIPTION
So this tries to solve #11.

Some major changes:
- You are now able to send non-QueueableCommands to the queue if it is in the command bus (not sure about this, but rather than always wrapping manually)
- The router makes the decision not to requeue the command
- If the command is not queueable by decision, it gets removed from any wrapper

Beat me, I couldn't find better names.

@rosstuck Enjoy
