### PR TITLE
Up the tactician version to .5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "bernard/bernard": "1.0.*@dev",
-        "league/tactician": "^0.4"
+        "league/tactician": "^0.5"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1",


### PR DESCRIPTION
As far as I can tell no changes from 0.4 to 0.5 of tactician have impact on how the bernard integration at this time. So it is safe to upgrade.
