### PR TITLE
Fix phpspec for php 7

### DIFF
--- a/spec/QueueCommandSpec.php
+++ b/spec/QueueCommandSpec.php
@@ -7,6 +7,9 @@ use Prophecy\Argument;
 
 class QueueCommandSpec extends ObjectBehavior
 {
+    /**
+     * @param \spec\League\Tactician\Bernard\Command $command
+     */
     function let(Command $command)
     {
         $this->beConstructedWith($command);
@@ -17,11 +20,17 @@ class QueueCommandSpec extends ObjectBehavior
         $this->shouldHaveType('League\Tactician\Bernard\QueueCommand');
     }
 
+    /**
+     * @param \spec\League\Tactician\Bernard\Command $command
+     */
     function it_has_a_command(Command $command)
     {
         $this->getCommand()->shouldReturn($command);
     }
 
+    /**
+     * @param \spec\League\Tactician\Bernard\Command $command
+     */
     function it_guesses_the_name_by_default()
     {
         $this->beConstructedWith(new Command);
@@ -29,6 +38,9 @@ class QueueCommandSpec extends ObjectBehavior
         $this->getName()->shouldReturn('Command');
     }
 
+    /**
+     * @param \spec\League\Tactician\Bernard\Command $command
+     */
     function it_accepts_a_name(Command $command)
     {
         $this->beConstructedWith($command, 'customName');

--- a/spec/QueueCommandSpec.php
+++ b/spec/QueueCommandSpec.php
@@ -10,7 +10,7 @@ class QueueCommandSpec extends ObjectBehavior
     /**
      * @param \spec\League\Tactician\Bernard\Command $command
      */
-    function let(Command $command)
+    function let($command)
     {
         $this->beConstructedWith($command);
     }
@@ -23,14 +23,11 @@ class QueueCommandSpec extends ObjectBehavior
     /**
      * @param \spec\League\Tactician\Bernard\Command $command
      */
-    function it_has_a_command(Command $command)
+    function it_has_a_command($command)
     {
         $this->getCommand()->shouldReturn($command);
     }
 
-    /**
-     * @param \spec\League\Tactician\Bernard\Command $command
-     */
     function it_guesses_the_name_by_default()
     {
         $this->beConstructedWith(new Command);
@@ -41,7 +38,7 @@ class QueueCommandSpec extends ObjectBehavior
     /**
      * @param \spec\League\Tactician\Bernard\Command $command
      */
-    function it_accepts_a_name(Command $command)
+    function it_accepts_a_name($command)
     {
         $this->beConstructedWith($command, 'customName');
 

--- a/spec/QueueMiddlewareSpec.php
+++ b/spec/QueueMiddlewareSpec.php
@@ -2,9 +2,6 @@
 
 namespace spec\League\Tactician\Bernard;
 
-use Bernard\Message;
-use Bernard\Producer;
-use League\Tactician\Middleware;
 use League\Tactician\Bernard\QueuedCommand;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -14,7 +11,7 @@ class QueueMiddlewareSpec extends ObjectBehavior
     /**
      * @param \Bernard\Producer $producer
      */
-    function let(Producer $producer)
+    function let($producer)
     {
         $this->beConstructedWith($producer);
     }
@@ -33,7 +30,7 @@ class QueueMiddlewareSpec extends ObjectBehavior
      * @param \Bernard\Producer $producer
      * @param \Bernard\Message  $command
      */
-    function it_executes_a_command(Producer $producer, Message $command)
+    function it_executes_a_command($producer, $command)
     {
         $producer->produce($command)->shouldBeCalled();
 
@@ -48,7 +45,7 @@ class QueueMiddlewareSpec extends ObjectBehavior
      * @param \Bernard\Producer            $producer
      * @param \League\Tactician\Middleware $middleware
      */
-    function it_executes_invokes_the_next_middleware(Producer $producer, Middleware $middleware)
+    function it_executes_invokes_the_next_middleware($producer, $middleware)
     {
         $command = new \stdClass;
         $producer->produce($command)->shouldNotBeCalled();
@@ -68,7 +65,7 @@ class QueueMiddlewareSpec extends ObjectBehavior
      * @param \Bernard\Message             $command
      * @param \League\Tactician\Middleware $middleware
      */
-    function it_unwraps_a_command(Producer $producer, Message $command, Middleware $middleware)
+    function it_unwraps_a_command($producer, $command, $middleware)
     {
         $queuedCommand = new QueuedCommand($command->getWrappedObject());
         $producer->produce($command)->shouldNotBeCalled();

--- a/spec/QueueMiddlewareSpec.php
+++ b/spec/QueueMiddlewareSpec.php
@@ -11,6 +11,9 @@ use Prophecy\Argument;
 
 class QueueMiddlewareSpec extends ObjectBehavior
 {
+    /**
+     * @param \Bernard\Producer $producer
+     */
     function let(Producer $producer)
     {
         $this->beConstructedWith($producer);
@@ -26,39 +29,55 @@ class QueueMiddlewareSpec extends ObjectBehavior
         $this->shouldImplement('League\Tactician\Middleware');
     }
 
+    /**
+     * @param \Bernard\Producer $producer
+     * @param \Bernard\Message  $command
+     */
     function it_executes_a_command(Producer $producer, Message $command)
     {
         $producer->produce($command)->shouldBeCalled();
 
-        $this->execute($command, function() {});
+        $this->execute(
+            $command,
+            function () {
+            }
+        );
     }
 
+    /**
+     * @param \Bernard\Producer            $producer
+     * @param \League\Tactician\Middleware $middleware
+     */
     function it_executes_invokes_the_next_middleware(Producer $producer, Middleware $middleware)
     {
         $command = new \stdClass;
-
         $producer->produce($command)->shouldNotBeCalled();
-        $next = function() {};
+        $next = function () {};
         $middleware->execute($command, $next)->willReturn(true);
 
         $this->execute(
             $command,
-            function($command) use ($middleware, $next) {
+            function ($command) use ($middleware, $next) {
                 return $middleware->execute($command, $next);
             }
         );
     }
 
+    /**
+     * @param \Bernard\Producer            $producer
+     * @param \Bernard\Message             $command
+     * @param \League\Tactician\Middleware $middleware
+     */
     function it_unwraps_a_command(Producer $producer, Message $command, Middleware $middleware)
     {
         $queuedCommand = new QueuedCommand($command->getWrappedObject());
         $producer->produce($command)->shouldNotBeCalled();
-        $next = function() {};
+        $next = function () {};
         $middleware->execute($command, $next)->willReturn(true);
 
         $this->execute(
             $queuedCommand,
-            function($command) use ($middleware, $next) {
+            function ($command) use ($middleware, $next) {
                 return $middleware->execute($command, $next);
             }
         );

--- a/spec/QueuedCommandSpec.php
+++ b/spec/QueuedCommandSpec.php
@@ -2,7 +2,6 @@
 
 namespace spec\League\Tactician\Bernard;
 
-use Bernard\Message;
 use PhpSpec\ObjectBehavior;
 
 class QueuedCommandSpec extends ObjectBehavior
@@ -10,7 +9,7 @@ class QueuedCommandSpec extends ObjectBehavior
     /**
      * @param \Bernard\Message $command
      */
-    function let(Message $command)
+    function let($command)
     {
         $this->beConstructedWith($command);
     }
@@ -23,7 +22,7 @@ class QueuedCommandSpec extends ObjectBehavior
     /**
      * @param \Bernard\Message $command
      */
-    function it_has_a_queueable_command(Message $command)
+    function it_has_a_queueable_command($command)
     {
         $this->getCommand()->shouldReturn($command);
     }

--- a/spec/QueuedCommandSpec.php
+++ b/spec/QueuedCommandSpec.php
@@ -7,6 +7,9 @@ use PhpSpec\ObjectBehavior;
 
 class QueuedCommandSpec extends ObjectBehavior
 {
+    /**
+     * @param \Bernard\Message $command
+     */
     function let(Message $command)
     {
         $this->beConstructedWith($command);
@@ -17,6 +20,9 @@ class QueuedCommandSpec extends ObjectBehavior
         $this->shouldHaveType('League\Tactician\Bernard\QueuedCommand');
     }
 
+    /**
+     * @param \Bernard\Message $command
+     */
     function it_has_a_queueable_command(Message $command)
     {
         $this->getCommand()->shouldReturn($command);

--- a/spec/Receiver/SameBusReceiverSpec.php
+++ b/spec/Receiver/SameBusReceiverSpec.php
@@ -2,8 +2,6 @@
 
 namespace spec\League\Tactician\Bernard\Receiver;
 
-use Bernard\Message;
-use League\Tactician\CommandBus;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -12,7 +10,7 @@ class SameBusReceiverSpec extends ObjectBehavior
     /**
      * @param \League\Tactician\CommandBus $commandBus
      */
-    function let(CommandBus $commandBus)
+    function let($commandBus)
     {
         $this->beConstructedWith($commandBus);
     }
@@ -27,7 +25,7 @@ class SameBusReceiverSpec extends ObjectBehavior
      * @param \League\Tactician\CommandBus $commandBus
      * @param \Bernard\Message    $command
      */
-    function it_handles_a_message(CommandBus $commandBus, Message $command)
+    function it_handles_a_message($commandBus, $command)
     {
         $commandBus->handle(Argument::type('League\Tactician\Bernard\QueuedCommand'))->willReturn(true);
 
@@ -38,7 +36,7 @@ class SameBusReceiverSpec extends ObjectBehavior
      * @param \League\Tactician\CommandBus $commandBus
      * @param \Bernard\Message    $command
      */
-    function it_is_invokable(CommandBus $commandBus, Message $command)
+    function it_is_invokable($commandBus, $command)
     {
         $commandBus->handle(Argument::type('League\Tactician\Bernard\QueuedCommand'))->willReturn(true);
 

--- a/spec/Receiver/SameBusReceiverSpec.php
+++ b/spec/Receiver/SameBusReceiverSpec.php
@@ -9,6 +9,9 @@ use Prophecy\Argument;
 
 class SameBusReceiverSpec extends ObjectBehavior
 {
+    /**
+     * @param \League\Tactician\CommandBus $commandBus
+     */
     function let(CommandBus $commandBus)
     {
         $this->beConstructedWith($commandBus);
@@ -20,6 +23,10 @@ class SameBusReceiverSpec extends ObjectBehavior
         $this->shouldHaveType('League\Tactician\Bernard\Receiver');
     }
 
+    /**
+     * @param \League\Tactician\CommandBus $commandBus
+     * @param \Bernard\Message    $command
+     */
     function it_handles_a_message(CommandBus $commandBus, Message $command)
     {
         $commandBus->handle(Argument::type('League\Tactician\Bernard\QueuedCommand'))->willReturn(true);
@@ -27,6 +34,10 @@ class SameBusReceiverSpec extends ObjectBehavior
         $this->handle($command)->shouldReturn(true);
     }
 
+    /**
+     * @param \League\Tactician\CommandBus $commandBus
+     * @param \Bernard\Message    $command
+     */
     function it_is_invokable(CommandBus $commandBus, Message $command)
     {
         $commandBus->handle(Argument::type('League\Tactician\Bernard\QueuedCommand'))->willReturn(true);

--- a/spec/Receiver/SeparateBusReceiverSpec.php
+++ b/spec/Receiver/SeparateBusReceiverSpec.php
@@ -2,8 +2,6 @@
 
 namespace spec\League\Tactician\Bernard\Receiver;
 
-use Bernard\Message;
-use League\Tactician\CommandBus;
 use PhpSpec\ObjectBehavior;
 
 class SeparateBusReceiverSpec extends ObjectBehavior
@@ -11,7 +9,7 @@ class SeparateBusReceiverSpec extends ObjectBehavior
     /**
      * @param \League\Tactician\CommandBus $commandBus
      */
-    function let(CommandBus $commandBus)
+    function let($commandBus)
     {
         $this->beConstructedWith($commandBus);
     }
@@ -26,7 +24,7 @@ class SeparateBusReceiverSpec extends ObjectBehavior
      * @param \League\Tactician\CommandBus $commandBus
      * @param \Bernard\Message    $command
      */
-    function it_handles_a_message(CommandBus $commandBus, Message $command)
+    function it_handles_a_message($commandBus, $command)
     {
         $commandBus->handle($command)->willReturn(true);
 
@@ -37,7 +35,7 @@ class SeparateBusReceiverSpec extends ObjectBehavior
      * @param \League\Tactician\CommandBus $commandBus
      * @param \Bernard\Message    $command
      */
-    function it_is_invokable(CommandBus $commandBus, Message $command)
+    function it_is_invokable($commandBus, $command)
     {
         $commandBus->handle($command)->willReturn(true);
 

--- a/spec/Receiver/SeparateBusReceiverSpec.php
+++ b/spec/Receiver/SeparateBusReceiverSpec.php
@@ -8,6 +8,9 @@ use PhpSpec\ObjectBehavior;
 
 class SeparateBusReceiverSpec extends ObjectBehavior
 {
+    /**
+     * @param \League\Tactician\CommandBus $commandBus
+     */
     function let(CommandBus $commandBus)
     {
         $this->beConstructedWith($commandBus);
@@ -19,6 +22,10 @@ class SeparateBusReceiverSpec extends ObjectBehavior
         $this->shouldHaveType('League\Tactician\Bernard\Receiver');
     }
 
+    /**
+     * @param \League\Tactician\CommandBus $commandBus
+     * @param \Bernard\Message    $command
+     */
     function it_handles_a_message(CommandBus $commandBus, Message $command)
     {
         $commandBus->handle($command)->willReturn(true);
@@ -26,6 +33,10 @@ class SeparateBusReceiverSpec extends ObjectBehavior
         $this->handle($command)->shouldReturn(true);
     }
 
+    /**
+     * @param \League\Tactician\CommandBus $commandBus
+     * @param \Bernard\Message    $command
+     */
     function it_is_invokable(CommandBus $commandBus, Message $command)
     {
         $commandBus->handle($command)->willReturn(true);


### PR DESCRIPTION
PHP uses a dirty trick to "abuse" the recoverable error/exception to catch the expected type to create mock, this dirty little secret is not possible in PHP 7.
